### PR TITLE
Update DJT Chat Discord link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 <hr class="dotted">
 <h4><a class="underscore" href="http://users3.smartgb.com/g/g.php?a=s&amp;i=g36-28922-76">feedback</a></h4>
 <h4><a class="underscore" href="https://discord.gg/bCK3Z83">Itazuraneko Discord</a></h4>
-<h4><a class="underscore" href="https://discord.gg/5K5jQjG">DJT Discord</a></h4>
+<h4><a class="underscore" href="https://animecards.site/discord/">DJT Discord</a></h4>
 <h4><a class="underscore" href="https://mega.nz/#F!IgZHiCLS!HFo3RFSjW8iFTEUTYo2Kng">site backup</a></h4>
 </div>
 <br>


### PR DESCRIPTION
This change lets me update the link later myself. Sometimes it changes due to channels being moved around or the server just being deleted.